### PR TITLE
[WIP] Use ZMS SignedDomains API and annotate updated RBACs

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"k8s.io/client-go/dynamic"
 	"log"
 	"os"
 	"os/signal"
@@ -54,6 +55,11 @@ func main() {
 		log.Panicln(err.Error())
 	}
 
+	dynClientSet, err := dynamic.NewForConfig(config)
+	if err != nil {
+		log.Panicln(err.Error())
+	}
+
 	namespaceListWatch := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "namespaces",
 		v1.NamespaceAll, fields.Everything())
 	namespaceIndexer, namespaceInformer := cache.NewIndexerInformer(namespaceListWatch, &v1.Namespace{}, 0,
@@ -71,6 +77,8 @@ func main() {
 		NamespaceIndexer: namespaceIndexer,
 		PollInterval:     pi,
 		DNSSuffix:        *dnsSuffix,
+		DynamicClientSet: dynClientSet,
+		DomainsLister:    zms.NewDomainsLister(),
 	}
 	go c.Run()
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,7 +3,20 @@
 // for terms.
 package util
 
-import "strings"
+import (
+	"fmt"
+	"github.com/davecgh/go-spew/spew"
+	"hash"
+	"hash/fnv"
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/model"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/dynamic"
+	"log"
+	"strings"
+)
 
 // DomainToNamespace will convert an athenz domain to a kubernetes namespace. Dots are converted to dashes
 // and dashes are converted to double dashes.
@@ -19,4 +32,58 @@ func DomainToNamespace(domain string) (namespace string) {
 func NamespaceToDomain(ns string) (domain string) {
 	dotted := strings.Replace(ns, "-", ".", -1)
 	return strings.Replace(dotted, "..", "-", -1)
+}
+
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}
+
+func ComputeHash(obj model.Config) string {
+	hasher := fnv.New32a()
+	DeepHashObject(hasher, obj.Spec)
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+}
+
+func GetPatch(domain string, tag string, hash string) (types.PatchType, []byte) {
+	return types.MergePatchType, []byte(fmt.Sprintf(`
+		{
+			"metadata": {
+				"annotations": { 
+					"authz.athenz.io/controller": "true",
+					"authz.athenz.io/domain": %q,
+					"authz.athenz.io/e-tag": %q,
+					"authz.athenz.io/spec-hash": %q
+				}
+			}
+		}`, domain, tag, hash))
+}
+
+func AnnotateModifiedResource(client dynamic.Interface, obj model.Config, domain string, tag string) error {
+
+	patchType, patch := GetPatch(domain, tag, ComputeHash(obj))
+	log.Printf("Patch bytes: %s", string(patch))
+
+	sch, ok := model.IstioConfigTypes.GetByType(obj.Type)
+	if !ok {
+		return fmt.Errorf("error determining the schema for the Istio resource: %s/%s/%s", crd.ResourceName(obj.Type), obj.Namespace, obj.Name)
+	}
+	resource, ns, name := schema.GroupVersionResource{
+		Group:    obj.Group,
+		Version:  obj.Version,
+		Resource: crd.ResourceName(sch.Plural),
+	}, obj.Namespace, obj.Name
+
+	res, err := client.Resource(resource).Namespace(ns).Patch(name, patchType, patch)
+	if err != nil {
+		return fmt.Errorf("error patching the servicerolebinding: %s", err.Error())
+	}
+	log.Printf("Patched resource: %+v", res)
+	return nil
 }


### PR DESCRIPTION
@mcieplak 
- Non-intrusive GetSignedDomains() API that fetches all metadata first call and then keep tracks of the E-Tag, and fetches the diff for every subsequent sync.
- Store the E-Tag on the SR & SRB resources as annotations along with the hash of the spec changes.

```
apiVersion: rbac.istio.io/v1alpha1
kind: ServiceRoleBinding
metadata:
  annotations:
    authz.athenz.io/controller: "true"
    authz.athenz.io/domain: home.mcieplak.db
    authz.athenz.io/e-tag: 2019-05-13T12:22:24.462Z
    authz.athenz.io/spec-hash: 58ff96669b
  creationTimestamp: 2019-05-07T18:59:26Z
  generation: 1
  name: home.mcieplak.db.details
  namespace: home-mcieplak-db
  resourceVersion: "231855553"
  selfLink: /apis/rbac.istio.io/v1alpha1/namespaces/home-mcieplak-db/servicerolebindings/home.mcieplak.db.details
  uid: 3befa316-70fa-11e9-87a9-008cfacc3c18
spec:
  roleRef:
    kind: ServiceRole
    name: home.mcieplak.db.details
  subjects:
  - user: home.mcieplak.ui/sa/productpage
  - user: home.prabushyam.subtest/sa/two-svc
```