### PR TITLE
Add support for namespace-level authorization in AuthorizationPolicy

### DIFF
--- a/pkg/istio/rbac/common/util.go
+++ b/pkg/istio/rbac/common/util.go
@@ -109,7 +109,7 @@ func CheckIfMemberIsAllUsers(member *zms.RoleMember, domainName zms.DomainName) 
 	memberStr := string(member.MemberName)
 
 	// if member name is of the form '<athenz-domain>.*', return namespace
-	if strings.HasPrefix(memberStr, "user.") || !strings.HasSuffix(memberStr, ".*") {
+	if strings.HasPrefix(memberStr, "unix.") || strings.HasPrefix(memberStr, "user.") || !strings.HasSuffix(memberStr, ".*") {
 		return "", nil
 	}
 

--- a/pkg/istio/rbac/common/util.go
+++ b/pkg/istio/rbac/common/util.go
@@ -98,9 +98,9 @@ func (a *ApiHandler) Delete(item *Item) error {
 	return err
 }
 
-// CheckIfMemberIsAllUsers returns namespace for Athenz domain when role member is of form '<athenz-domain>.*'.
+// CheckIfMemberIsAllUsersFromDomain returns namespace for Athenz domain when role member is of form '<athenz-domain>.*'.
 // Example: domain.sub-domain.* -> domain-sub--domain
-func CheckIfMemberIsAllUsers(member *zms.RoleMember, domainName zms.DomainName) (string, error) {
+func CheckIfMemberIsAllUsersFromDomain(member *zms.RoleMember, domainName zms.DomainName) (string, error) {
 
 	if member == nil {
 		return "", fmt.Errorf("member is nil")

--- a/pkg/istio/rbac/v2/provider.go
+++ b/pkg/istio/rbac/v2/provider.go
@@ -133,14 +133,6 @@ func (p *v2) ConvertAthenzModelIntoIstioRbac(athenzModel athenz.Model, serviceNa
 				log.Infoln("member expired, skip adding member to authz policy resource, member: ", roleMember.MemberName)
 				continue
 			}
-			if p.enableOriginJwtSubject {
-				originJwtName, err := common.MemberToOriginJwtSubject(roleMember)
-				if err != nil {
-					log.Errorln(err.Error())
-					continue
-				}
-				from_requestPrincipal.Source.RequestPrincipals = append(from_requestPrincipal.Source.RequestPrincipals, originJwtName)
-			}
 			namespace, err := common.CheckIfMemberIsAllUsers(roleMember, athenzModel.Name)
 			if err != nil {
 				log.Errorln("error checking if role member is all users in an Athenz domain: ", err.Error())
@@ -156,6 +148,14 @@ func (p *v2) ConvertAthenzModelIntoIstioRbac(athenzModel athenz.Model, serviceNa
 				continue
 			}
 			from_principal.Source.Principals = append(from_principal.Source.Principals, spiffeName)
+			if p.enableOriginJwtSubject {
+				originJwtName, err := common.MemberToOriginJwtSubject(roleMember)
+				if err != nil {
+					log.Errorln(err.Error())
+					continue
+				}
+				from_requestPrincipal.Source.RequestPrincipals = append(from_requestPrincipal.Source.RequestPrincipals, originJwtName)
+			}
 		}
 		//add role spiffe for role certificate
 		roleSpiffeName, err := common.RoleToSpiffe(string(athenzModel.Name), string(role))

--- a/pkg/istio/rbac/v2/provider.go
+++ b/pkg/istio/rbac/v2/provider.go
@@ -133,7 +133,7 @@ func (p *v2) ConvertAthenzModelIntoIstioRbac(athenzModel athenz.Model, serviceNa
 				log.Infoln("member expired, skip adding member to authz policy resource, member: ", roleMember.MemberName)
 				continue
 			}
-			namespace, err := common.CheckIfMemberIsAllUsers(roleMember, athenzModel.Name)
+			namespace, err := common.CheckIfMemberIsAllUsersFromDomain(roleMember, athenzModel.Name)
 			if err != nil {
 				log.Errorln("error checking if role member is all users in an Athenz domain: ", err.Error())
 				continue

--- a/pkg/istio/rbac/v2/provider_test.go
+++ b/pkg/istio/rbac/v2/provider_test.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	domainName       = "test.namespace"
-	username         = "user.name"
-	wildcardUsername = "user.*"
-	wildcardAllUsers = "test-domain.namespace2.*"
+	domainName                 = "test.namespace"
+	username                   = "user.name"
+	wildcardUsername           = "user.*"
+	wildcardAllUsersFromDomain = "test-domain.namespace2.*"
 )
 
 var (
@@ -346,7 +346,7 @@ func getFakeOnboardedDomain() zms.SignedDomain {
 							MemberName: wildcardUsername,
 						},
 						{
-							MemberName: wildcardAllUsers,
+							MemberName: wildcardAllUsersFromDomain,
 						},
 					},
 				},

--- a/pkg/istio/rbac/v2/provider_test.go
+++ b/pkg/istio/rbac/v2/provider_test.go
@@ -4,6 +4,10 @@
 package v2
 
 import (
+	"sort"
+	"testing"
+	"time"
+
 	"github.com/ardielle/ardielle-go/rdl"
 	"github.com/stretchr/testify/assert"
 	"github.com/yahoo/athenz/clients/go/zms"
@@ -18,15 +22,13 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
-	"sort"
-	"testing"
-	"time"
 )
 
 const (
 	domainName       = "test.namespace"
 	username         = "user.name"
 	wildcardUsername = "user.*"
+	wildcardAllUsers = "test-domain.namespace2.*"
 )
 
 var (
@@ -220,8 +222,16 @@ func getExpectedAuthzPolicy() []model.Config {
 					},
 					{
 						Source: &v1beta1.Source{
+							Namespaces: []string{
+								"test--domain-namespace2",
+							},
+						},
+					},
+					{
+						Source: &v1beta1.Source{
 							RequestPrincipals: []string{
 								"*",
+								"athenz/test-domain.namespace2.*",
 							},
 						},
 					},
@@ -335,6 +345,9 @@ func getFakeOnboardedDomain() zms.SignedDomain {
 					RoleMembers: []*zms.RoleMember{
 						{
 							MemberName: wildcardUsername,
+						},
+						{
+							MemberName: wildcardAllUsers,
 						},
 					},
 				},

--- a/pkg/istio/rbac/v2/provider_test.go
+++ b/pkg/istio/rbac/v2/provider_test.go
@@ -231,7 +231,6 @@ func getExpectedAuthzPolicy() []model.Config {
 						Source: &v1beta1.Source{
 							RequestPrincipals: []string{
 								"*",
-								"athenz/test-domain.namespace2.*",
 							},
 						},
 					},


### PR DESCRIPTION
This PR adds support for authorizing entire K8s namespaces when role members on Athenz are of the form `<athenz-domain>.*`, as described by https://github.com/yahoo/k8s-athenz-istio-auth/issues/56.

Expected translation:
**Role member** like `test-domain.namespace.*` leads to  the **K8s namespace** named `test--domain-namespace` getting added to the list of sources in the authz policy's rules.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.